### PR TITLE
Add _FILE Support For User And Databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ Most variables are the same as in the [official postgres image](https://hub.dock
 | BACKUP_KEEP_MONTHS | Number of monthly backups to keep before removal. Defaults to `6`. |
 | HEALTHCHECK_PORT | Port listening for cron-schedule health check. Defaults to `8080`. |
 | POSTGRES_DB | Comma or space separated list of postgres databases to backup. Required. |
+| POSTGRES_DB_FILE | Alternative to POSTGRES_DB, for usage with docker secrets. |
 | POSTGRES_EXTRA_OPTS | Additional options for `pg_dump`. Defaults to `-Z9`. |
 | POSTGRES_HOST | Postgres connection parameter; postgres host to connect to. Required. |
 | POSTGRES_PASSWORD | Postgres connection parameter; postgres password to connect with. Required. |
-| POSTGRES_PASSWORD_FILE | Alternative to POSTGRES_PASSWORD, useful with docker secrets. |
+| POSTGRES_PASSWORD_FILE | Alternative to POSTGRES_PASSWORD, for usage with docker secrets. |
 | POSTGRES_PORT | Postgres connection parameter; postgres port to connect to. Defaults to `5432`. |
 | POSTGRES_USER | Postgres connection parameter; postgres user to connect with. Required. |
+| POSTGRES_USER_FILE | Alternative to POSTGRES_USER, for usage with docker secrets. |
 | SCHEDULE | [Cron-schedule](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules) specifying the interval between postgres backups. Defaults to `@daily`. |
 
 ### Manual Backups

--- a/backup.sh
+++ b/backup.sh
@@ -2,8 +2,8 @@
 
 set -e
 
-if [ "${POSTGRES_DB}" = "**None**" ]; then
-  echo "You need to set the POSTGRES_DB environment variable."
+if [ "${POSTGRES_DB}" = "**None**" -a "${POSTGRES_DB_FILE}" = "**None**" ]; then
+  echo "You need to set the POSTGRES_DB or POSTGRES_DB_FILE environment variable."
   exit 1
 fi
 
@@ -17,23 +17,39 @@ if [ "${POSTGRES_HOST}" = "**None**" ]; then
   fi
 fi
 
-if [ "${POSTGRES_USER}" = "**None**" ]; then
-  echo "You need to set the POSTGRES_USER environment variable."
+if [ "${POSTGRES_USER}" = "**None**" -a "${POSTGRES_USER_FILE}" = "**None**" ]; then
+  echo "You need to set the POSTGRES_USER or POSTGRES_USER_FILE environment variable."
   exit 1
 fi
 
 if [ "${POSTGRES_PASSWORD}" = "**None**" -a "${POSTGRES_PASSWORD_FILE}" = "**None**" ]; then
-  echo "You need to set the POSTGRES_PASSWORD environment variable or link to a container named POSTGRES."
+  echo "You need to set the POSTGRES_PASSWORD or POSTGRES_PASSWORD_FILE environment variable or link to a container named POSTGRES."
   exit 1
 fi
 
-#Proces vars
+#Process vars
+if [ "${POSTGRES_DB_FILE}" = "**None**" ]; then
+  export POSTGRES_DB=$POSTGRES_DB
+elif [ -r "${POSTGRES_DB_FILE}" ]; then
+  export POSTGRES_DB=$(cat ${POSTGRES_DB_FILE})
+else
+  echo "Missing POSTGRES_DB_FILE file."
+  exit 1
+fi
 if [ "${POSTGRES_PASSWORD_FILE}" = "**None**" ]; then
   export PGPASSWORD=$POSTGRES_PASSWORD
 elif [ -r "${POSTGRES_PASSWORD_FILE}" ]; then
   export PGPASSWORD=$(cat ${POSTGRES_PASSWORD_FILE})
 else
   echo "Missing POSTGRES_PASSWORD_FILE file."
+  exit 1
+fi
+if [ "${POSTGRES_USER_FILE}" = "**None**" ]; then
+  export POSTGRES_USER=$POSTGRES_USER
+elif [ -r "${POSTGRES_USER_FILE}" ]; then
+  export POSTGRES_USER=$(cat ${POSTGRES_USER_FILE})
+else
+  echo "Missing POSTGRES_USER_FILE file."
   exit 1
 fi
 POSTGRES_HOST_OPTS="-h $POSTGRES_HOST -p $POSTGRES_PORT -U $POSTGRES_USER $POSTGRES_EXTRA_OPTS"


### PR DESCRIPTION
This PR aligns supported Docker secrets with those in the official Postgres image (except `POSTGRES_INITDB_ARGS`). It's doesn't break backwards compatiblity as it only adds the possibility to use secrets for username and database names.

Follows #15.