### PR TITLE
BACKUP_KEEP_N_* options

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,12 @@ Most variables are the same as in the [official postgres image](https://hub.dock
 |--|--|
 | BACKUP_DIR | Directory to save the backup at. Defaults to `/backups`. |
 | BACKUP_SUFFIX | Filename suffix to save the backup. Defaults to `.sql.gz`. |
-| BACKUP_KEEP_DAYS | Number of daily backups to keep before removal. Defaults to `7`. |
-| BACKUP_KEEP_WEEKS | Number of weekly backups to keep before removal. Defaults to `4`. |
-| BACKUP_KEEP_MONTHS | Number of monthly backups to keep before removal. Defaults to `6`. |
+| BACKUP_KEEP_DAYS | Number of days to keep backups for. Defaults to `7`. |
+| BACKUP_KEEP_WEEKS | Number of weeks to keep backups for. Defaults to `4`. |
+| BACKUP_KEEP_MONTHS | Number of months to keep backups for. Defaults to `6`. |
+| BACKUP_KEEP_N_DAILY | Number of daily backups to keep before removal. Disabled by default. |
+| BACKUP_KEEP_N_WEEKLY | Number of weekly backups to keep before removal. Disabled by default. |
+| BACKUP_KEEP_N_MONTHLY | Number of monthly backups to keep before removal. Disabled by default. |
 | HEALTHCHECK_PORT | Port listening for cron-schedule health check. Defaults to `8080`. |
 | POSTGRES_DB | Comma or space separated list of postgres databases to backup. Required. |
 | POSTGRES_DB_FILE | Alternative to POSTGRES_DB, but with one database per line, for usage with docker secrets. |

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -26,6 +26,9 @@ ENV POSTGRES_DB="**None**" \
     BACKUP_KEEP_DAYS=7 \
     BACKUP_KEEP_WEEKS=4 \
     BACKUP_KEEP_MONTHS=6 \
+    BACKUP_KEEP_N_DAILY="**None**" \
+    BACKUP_KEEP_N_WEEKLY="**None**" \
+    BACKUP_KEEP_N_MONTHLY="**None**" \
     HEALTHCHECK_PORT=8080
 
 COPY backup.sh /backup.sh

--- a/backup.sh
+++ b/backup.sh
@@ -92,11 +92,31 @@ for DB in ${POSTGRES_DBS}; do
     ln -vf "${DFILE}" "${WFILE}"
     ln -vf "${DFILE}" "${MFILE}"
   fi
+
   #Clean old files
+
   echo "Cleaning older than ${KEEP_DAYS} days for ${DB} database from ${POSTGRES_HOST}..."
   find "${BACKUP_DIR}/daily" -maxdepth 1 -mtime +${KEEP_DAYS} -name "${DB}-*${BACKUP_SUFFIX}" -exec rm -rf '{}' ';'
   find "${BACKUP_DIR}/weekly" -maxdepth 1 -mtime +${KEEP_WEEKS} -name "${DB}-*${BACKUP_SUFFIX}" -exec rm -rf '{}' ';'
   find "${BACKUP_DIR}/monthly" -maxdepth 1 -mtime +${KEEP_MONTHS} -name "${DB}-*${BACKUP_SUFFIX}" -exec rm -rf '{}' ';'
+
+  if [ "${BACKUP_KEEP_N_DAILY}" != "**None**" ]; then
+    echo "Cleaning those that are not the most recent ${BACKUP_KEEP_N_DAILY} daily for ${DB} database from ${POSTGRES_HOST}..."
+    find "${BACKUP_DIR}/daily" -maxdepth 1 -name "${DB}-*${BACKUP_SUFFIX}" -printf "%T@ %p\n" \
+      | sort -nr | cut -d " " -f2 | tail -n +$(($BACKUP_KEEP_N_DAILY+1)) | xargs rm -rf
+  fi
+
+  if [ "${BACKUP_KEEP_N_WEEKLY}" != "**None**" ]; then
+    echo "Cleaning those that are not the most recent ${BACKUP_KEEP_N_WEEKLY} weekly for ${DB} database from ${POSTGRES_HOST}..."
+    find "${BACKUP_DIR}/weekly" -maxdepth 1 -name "${DB}-*${BACKUP_SUFFIX}" -printf "%T@ %p\n" \
+      | sort -nr | cut -d " " -f2 | tail -n +$(($BACKUP_KEEP_N_WEEKLY+1)) | xargs rm -rf
+  fi
+
+  if [ "${BACKUP_KEEP_N_MONTHLY}" != "**None**" ]; then
+    echo "Cleaning those that are not the most recent ${BACKUP_KEEP_N_MONTHLY} monthly for ${DB} database from ${POSTGRES_HOST}..."
+    find "${BACKUP_DIR}/monthly" -maxdepth 1 -name "${DB}-*${BACKUP_SUFFIX}" -printf "%T@ %p\n" \
+      | sort -nr | cut -d " " -f2 | tail -n +$(($BACKUP_KEEP_N_MONTHLY+1)) | xargs rm -rf
+  fi
 done
 
 echo "SQL backup created successfully"

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -27,6 +27,9 @@ ENV POSTGRES_DB="**None**" \
     BACKUP_KEEP_DAYS=7 \
     BACKUP_KEEP_WEEKS=4 \
     BACKUP_KEEP_MONTHS=6 \
+    BACKUP_KEEP_N_DAILY="**None**" \
+    BACKUP_KEEP_N_WEEKLY="**None**" \
+    BACKUP_KEEP_N_MONTHLY="**None**" \
     HEALTHCHECK_PORT=8080
 
 COPY backup.sh /backup.sh


### PR DESCRIPTION
I think there are two methods one might whish to delete old backups:
+ By date. e.g. "delete all backups older than 22 days"
+ By number. e.g. "delete all backups except the most recent 5"

The removal by date method is already implemented and customizable using the `BACKUP_KEEP_DAYS`, `BACKUP_KEEP_WEEKS` and `BACKUP_KEEP_MONTHS`.

On a side note: I found the documentation for these quite confusing: the README says "Number of daily backups to keep before removal." making one think backups are deleted/kept based on their number. But in fact they're deleted based on the datetime they were last modified. So I made it a little more clear by writing: "Number of days to keep backups for."

In this PR I add options `BACKUP_KEEP_N_DAILY`, `BACKUP_KEEP_N_WEEKLY` and `BACKUP_KEEP_N_MONTHLY` which implement removal by number. e.g. if you set `BACKUP_KEEP_N_DAILY` to 5, then only the most recent 5 backups will ever be present in directory `${BACKUP_DIR}/daily`.

I find this quite useful in this scenario: you want backups to be frequent to make for an easier system recovery (because of more up-to-date data) and you don't care so much about older backups. For instance I need to make backups every 5m but I only ever care about the last one. Before this PR I could only set `BACKUP_KEEP_DAYS` to 1 but I would still end up with 288 backups and roughly 100GB of wasted disk space.

Thank you for your time in reviewing this PR. @prodrigestivill 
