### PR TITLE
Remove generating images for postgresql 10 & 11

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -6,7 +6,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN set -x \
 	&& apk update && apk add ca-certificates curl \
-	&& curl -L https://github.com/prodrigestivill/go-cron/releases/download/$GOCRONVER/go-cron-$TARGETOS-$TARGETARCH-static.gz | zcat > /usr/local/bin/go-cron \
+	&& curl --fail --retry 4 --retry-all-errors -L https://github.com/prodrigestivill/go-cron/releases/download/$GOCRONVER/go-cron-$TARGETOS-$TARGETARCH-static.gz | zcat > /usr/local/bin/go-cron \
 	&& chmod a+x /usr/local/bin/go-cron
 
 ENV POSTGRES_DB="**None**" \

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -20,7 +20,7 @@ RUN set -x \
 
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates curl && apt-get clean && rm -rf /var/lib/apt/lists/* \
-	&& curl -o /usr/local/bin/go-cron.gz -L https://github.com/prodrigestivill/go-cron/releases/download/$GOCRONVER/go-cron-$TARGETOS-$TARGETARCH.gz \
+	&& curl --fail --retry 4 --retry-all-errors -o /usr/local/bin/go-cron.gz -L https://github.com/prodrigestivill/go-cron/releases/download/$GOCRONVER/go-cron-$TARGETOS-$TARGETARCH.gz \
 	&& gzip -vnd /usr/local/bin/go-cron.gz && chmod a+x /usr/local/bin/go-cron
 
 ENV POSTGRES_DB="**None**" \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-	targets = ["debian-latest", "alpine-latest", "debian-14", "debian-13", "debian-12", "debian-11", "alpine-14", "alpine-13", "alpine-12", "alpine-11"]
+	targets = ["debian-latest", "alpine-latest", "debian-14", "debian-13", "debian-12", "alpine-14", "alpine-13", "alpine-12"]
 }
 
 variable "REGISTRY_PREFIX" {
@@ -103,25 +103,5 @@ target "alpine-12" {
 	tags = [
 		"${REGISTRY_PREFIX}${IMAGE_NAME}:12-alpine",
 		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:12-alpine-${BUILD_REVISION}" : ""
-	]
-}
-
-target "debian-11" {
-	inherits = ["debian"]
-	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
-	args = {"BASETAG" = "11"}
-	tags = [
-		"${REGISTRY_PREFIX}${IMAGE_NAME}:11",
-		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:11-debian-${BUILD_REVISION}" : ""
-	]
-}
-
-target "alpine-11" {
-	inherits = ["alpine"]
-	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x", "linux/ppc64le"]
-	args = {"BASETAG" = "11-alpine"}
-	tags = [
-		"${REGISTRY_PREFIX}${IMAGE_NAME}:11-alpine",
-		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:11-alpine-${BUILD_REVISION}" : ""
 	]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-	targets = ["debian-latest", "alpine-latest", "debian-14", "debian-13", "debian-12", "debian-11", "debian-10", "alpine-14", "alpine-13", "alpine-12", "alpine-11", "alpine-10"]
+	targets = ["debian-latest", "alpine-latest", "debian-14", "debian-13", "debian-12", "debian-11", "alpine-14", "alpine-13", "alpine-12", "alpine-11"]
 }
 
 variable "REGISTRY_PREFIX" {
@@ -123,25 +123,5 @@ target "alpine-11" {
 	tags = [
 		"${REGISTRY_PREFIX}${IMAGE_NAME}:11-alpine",
 		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:11-alpine-${BUILD_REVISION}" : ""
-	]
-}
-
-target "debian-10" {
-	inherits = ["debian"]
-	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
-	args = {"BASETAG" = "10"}
-	tags = [
-		"${REGISTRY_PREFIX}${IMAGE_NAME}:10",
-		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:10-debian-${BUILD_REVISION}" : ""
-	]
-}
-
-target "alpine-10" {
-	inherits = ["alpine"]
-	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x", "linux/ppc64le"]
-	args = {"BASETAG" = "10-alpine"}
-	tags = [
-		"${REGISTRY_PREFIX}${IMAGE_NAME}:10-alpine",
-		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:10-alpine-${BUILD_REVISION}" : ""
 	]
 }

--- a/generate-docker-bake.sh
+++ b/generate-docker-bake.sh
@@ -6,16 +6,13 @@ GOCRONVER="v0.0.10"
 MAIN_TAG="15"
 TAGS_EXTRA="14 13 12"
 PLATFORMS="linux/amd64 linux/arm64 linux/arm/v7 linux/s390x linux/ppc64le"
-TAGS_EXTRA_2="11"
-PLATFORMS_DEBIAN_2="linux/amd64 linux/arm64 linux/arm/v7"
 DOCKER_BAKE_FILE="${1:-docker-bake.hcl}"
 
 cd "$(dirname "$0")"
 
 P="\"$(echo $PLATFORMS | sed 's/ /", "/g')\""
-P2="\"$(echo $PLATFORMS_DEBIAN_2 | sed 's/ /", "/g')\""
 
-T="\"debian-latest\", \"alpine-latest\", \"$(echo debian-$TAGS_EXTRA $TAGS_EXTRA_2 | sed 's/ /", "debian-/g')\", \"$(echo alpine-$TAGS_EXTRA $TAGS_EXTRA_2 | sed 's/ /", "alpine-/g')\""
+T="\"debian-latest\", \"alpine-latest\", \"$(echo debian-$TAGS_EXTRA | sed 's/ /", "debian-/g')\", \"$(echo alpine-$TAGS_EXTRA | sed 's/ /", "alpine-/g')\""
 
 cat > "$DOCKER_BAKE_FILE" << EOF
 group "default" {
@@ -72,30 +69,6 @@ for TAG in $TAGS_EXTRA; do cat >> "$DOCKER_BAKE_FILE" << EOF
 target "debian-$TAG" {
 	inherits = ["debian"]
 	platforms = [$P]
-	args = {"BASETAG" = "$TAG"}
-	tags = [
-		"\${REGISTRY_PREFIX}\${IMAGE_NAME}:$TAG",
-		notequal("", BUILD_REVISION) ? "\${REGISTRY_PREFIX}\${IMAGE_NAME}:$TAG-debian-\${BUILD_REVISION}" : ""
-	]
-}
-
-target "alpine-$TAG" {
-	inherits = ["alpine"]
-	platforms = [$P]
-	args = {"BASETAG" = "$TAG-alpine"}
-	tags = [
-		"\${REGISTRY_PREFIX}\${IMAGE_NAME}:$TAG-alpine",
-		notequal("", BUILD_REVISION) ? "\${REGISTRY_PREFIX}\${IMAGE_NAME}:$TAG-alpine-\${BUILD_REVISION}" : ""
-	]
-}
-EOF
-done
-
-for TAG in $TAGS_EXTRA_2; do cat >> "$DOCKER_BAKE_FILE" << EOF
-
-target "debian-$TAG" {
-	inherits = ["debian"]
-	platforms = [$P2]
 	args = {"BASETAG" = "$TAG"}
 	tags = [
 		"\${REGISTRY_PREFIX}\${IMAGE_NAME}:$TAG",

--- a/generate-docker-bake.sh
+++ b/generate-docker-bake.sh
@@ -6,7 +6,7 @@ GOCRONVER="v0.0.10"
 MAIN_TAG="15"
 TAGS_EXTRA="14 13 12"
 PLATFORMS="linux/amd64 linux/arm64 linux/arm/v7 linux/s390x linux/ppc64le"
-TAGS_EXTRA_2="11 10"
+TAGS_EXTRA_2="11"
 PLATFORMS_DEBIAN_2="linux/amd64 linux/arm64 linux/arm/v7"
 DOCKER_BAKE_FILE="${1:-docker-bake.hcl}"
 


### PR DESCRIPTION
- Remove generating version 10 of PostgreSQL since it isn't [supported officially](https://www.postgresql.org/support/versioning/) anymore.
- Remove generating version 11 of PostgreSQL since the base docker image has an invalid debian repo.
- Added curl retry to avoid other CI problems generating the images when GitHub CDN is returning 404.