### PR TITLE
Fix compression in pg_dump and make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Most variables are the same as in the [official postgres image](https://hub.dock
 | BACKUP_KEEP_WEEKS | Number of weekly backups to keep before removal. Defaults to `4`. |
 | BACKUP_KEEP_MONTHS | Number of monthly backups to keep before removal. Defaults to `6`. |
 | BACKUP_KEEP_MINS | Number of minutes for `last` folder backups to keep before removal. Defaults to `1440`. |
-| COMPRESS_BACKUPS | Compresses backups using `gzip`. Significantly reduces backup size, recommended to leave enabled unless you have a reason to disable it. Defaults to `true`. |
+| COMPRESS_BACKUPS | Compresses backups using `gzip`. Significantly reduces backup size, recommended to leave enabled unless you have a reason to disable it. Defaults to `TRUE`. |
 | HEALTHCHECK_PORT | Port listening for cron-schedule health check. Defaults to `8080`. |
 | POSTGRES_DB | Comma or space separated list of postgres databases to backup. Required. |
 | POSTGRES_DB_FILE | Alternative to POSTGRES_DB, but with one database per line, for usage with docker secrets. |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Most variables are the same as in the [official postgres image](https://hub.dock
 | BACKUP_KEEP_WEEKS | Number of weekly backups to keep before removal. Defaults to `4`. |
 | BACKUP_KEEP_MONTHS | Number of monthly backups to keep before removal. Defaults to `6`. |
 | BACKUP_KEEP_MINS | Number of minutes for `last` folder backups to keep before removal. Defaults to `1440`. |
+| COMPRESS_BACKUPS | Compresses backups using `gzip`. Significantly reduces backup size, recommended to leave enabled unless you have a reason to disable it. Defaults to `true`. |
 | HEALTHCHECK_PORT | Port listening for cron-schedule health check. Defaults to `8080`. |
 | POSTGRES_DB | Comma or space separated list of postgres databases to backup. Required. |
 | POSTGRES_DB_FILE | Alternative to POSTGRES_DB, but with one database per line, for usage with docker secrets. |

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -9,7 +9,8 @@ RUN set -x \
 	&& curl --fail --retry 4 --retry-all-errors -L https://github.com/prodrigestivill/go-cron/releases/download/$GOCRONVER/go-cron-$TARGETOS-$TARGETARCH-static.gz | zcat > /usr/local/bin/go-cron \
 	&& chmod a+x /usr/local/bin/go-cron
 
-ENV POSTGRES_DB="**None**" \
+ENV COMPRESS_BACKUPS="TRUE" \
+    POSTGRES_DB="**None**" \
     POSTGRES_DB_FILE="**None**" \
     POSTGRES_HOST="**None**" \
     POSTGRES_PORT=5432 \

--- a/backup.sh
+++ b/backup.sh
@@ -90,10 +90,18 @@ for DB in ${POSTGRES_DBS}; do
   #Create dump
   if [ "${POSTGRES_CLUSTER}" = "TRUE" ]; then
     echo "Creating cluster dump of ${DB} database from ${POSTGRES_HOST}..."
-    pg_dumpall -l "${DB}" ${POSTGRES_EXTRA_OPTS} | gzip > "${FILE}"
+    if [ "${COMPRESS_BACKUPS}" = "TRUE" ]; then
+      pg_dumpall -l "${DB}" ${POSTGRES_EXTRA_OPTS} | gzip > "${FILE}"
+    else
+      pg_dumpall -l "${DB}" ${POSTGRES_EXTRA_OPTS} > "${FILE}"
+    fi
   else
     echo "Creating dump of ${DB} database from ${POSTGRES_HOST}..."
-    pg_dump -d "${DB}" -f "${FILE}" ${POSTGRES_EXTRA_OPTS}
+    if [ "${COMPRESS_BACKUPS}" = "TRUE" ]; then
+      pg_dump -d "${DB}" ${POSTGRES_EXTRA_OPTS} | gzip > "${FILE}"
+    else
+      pg_dump -d "${DB}" ${POSTGRES_EXTRA_OPTS} > "${FILE}"
+    fi
   fi
   #Copy (hardlink) for each entry
   if [ -d "${FILE}" ]; then

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -23,7 +23,8 @@ RUN set -x \
 	&& curl --fail --retry 4 --retry-all-errors -o /usr/local/bin/go-cron.gz -L https://github.com/prodrigestivill/go-cron/releases/download/$GOCRONVER/go-cron-$TARGETOS-$TARGETARCH.gz \
 	&& gzip -vnd /usr/local/bin/go-cron.gz && chmod a+x /usr/local/bin/go-cron
 
-ENV POSTGRES_DB="**None**" \
+ENV COMPRESS_BACKUPS="true" \
+    POSTGRES_DB="**None**" \
     POSTGRES_DB_FILE="**None**" \
     POSTGRES_HOST="**None**" \
     POSTGRES_PORT=5432 \

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -23,7 +23,7 @@ RUN set -x \
 	&& curl --fail --retry 4 --retry-all-errors -o /usr/local/bin/go-cron.gz -L https://github.com/prodrigestivill/go-cron/releases/download/$GOCRONVER/go-cron-$TARGETOS-$TARGETARCH.gz \
 	&& gzip -vnd /usr/local/bin/go-cron.gz && chmod a+x /usr/local/bin/go-cron
 
-ENV COMPRESS_BACKUPS="true" \
+ENV COMPRESS_BACKUPS="TRUE" \
     POSTGRES_DB="**None**" \
     POSTGRES_DB_FILE="**None**" \
     POSTGRES_HOST="**None**" \


### PR DESCRIPTION
- The `pg_dump` call never actually compressed the data, only `pg_dumpall` did. This PR fixes that.

- Made compression optional, as there are a few to not want to compress the backups. This is done via an environment variable named `COMPRESS_BACKUPS` which defaults to compress, and is documented in the README.