### PR TITLE
Add granular webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ Most variables are the same as in the [official postgres image](https://hub.dock
 | SCHEDULE | [Cron-schedule](http://godoc.org/github.com/robfig/cron#hdr-Predefined_schedules) specifying the interval between postgres backups. Defaults to `@daily`. |
 | TZ | [POSIX TZ variable](https://www.gnu.org/software/libc/manual/html_node/TZ-Variable.html) specifying the timezone used to evaluate SCHEDULE cron (example "Europe/Paris"). |
 | WEBHOOK_URL | URL to be called after an error or after a successful backup (POST with a JSON payload, check `hooks/00-webhook` file for more info). Default disabled. |
+| WEBHOOK_ERROR_URL | URL to be called in case backup fails. Default disabled. |
+| WEBHOOK_PRE_BACKUP_URL | URL to be called when backup starts. Default disabled. |
+| WEBHOOK_POST_BACKUP_URL | URL to be called when backup completes successfully. Default disabled. |
 | WEBHOOK_EXTRA_ARGS | Extra arguments for the `curl` execution in the webhook (check `hooks/00-webhook` file for more info). |
 
 #### Special Environment Variables

--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -30,6 +30,9 @@ ENV POSTGRES_DB="**None**" \
     BACKUP_KEEP_MINS=1440 \
     HEALTHCHECK_PORT=8080 \
     WEBHOOK_URL="**None**" \
+    WEBHOOK_ERROR_URL="**None**" \
+    WEBHOOK_PRE_BACKUP_URL="**None**" \
+    WEBHOOK_POST_BACKUP_URL="**None**" \
     WEBHOOK_EXTRA_ARGS=""
 
 COPY hooks /hooks

--- a/debian.Dockerfile
+++ b/debian.Dockerfile
@@ -44,6 +44,9 @@ ENV POSTGRES_DB="**None**" \
     BACKUP_KEEP_MINS=1440 \
     HEALTHCHECK_PORT=8080 \
     WEBHOOK_URL="**None**" \
+    WEBHOOK_ERROR_URL="**None**" \
+    WEBHOOK_PRE_BACKUP_URL="**None**" \
+    WEBHOOK_POST_BACKUP_URL="**None**" \
     WEBHOOK_EXTRA_ARGS=""
 
 COPY hooks /hooks

--- a/hooks/00-webhook
+++ b/hooks/00-webhook
@@ -32,3 +32,45 @@ if [ "${WEBHOOK_URL}" != "**None**" ]; then
       ;;
   esac
 fi
+
+case "${ACTION}" in
+  "error")
+    if [ "${WEBHOOK_ERROR_URL}" != "**None**" ]; then
+      echo "Execute error webhook call to ${WEBHOOK_ERROR_URL}"
+      curl --request POST \
+        --url "${WEBHOOK_ERROR_URL}" \
+        --header 'Content-Type: application/json' \
+        --data '{"status": "error"}' \
+        --max-time 10 \
+        --retry 5 \
+        ${WEBHOOK_EXTRA_ARGS}
+    fi
+  ;;
+
+  "pre-backup")
+    if [ "${WEBHOOK_PRE_BACKUP_URL}" != "**None**" ]; then
+      echo "Execute pre-backup webhook call to ${WEBHOOK_PRE_BACKUP_URL}"
+      curl --request POST \
+        --url "${WEBHOOK_PRE_BACKUP_URL}" \
+        --header 'Content-Type: application/json' \
+        --data '{"status": "error"}' \
+        --max-time 10 \
+        --retry 5 \
+        ${WEBHOOK_EXTRA_ARGS}
+    fi
+  ;;
+
+  "post-backup")
+    if [ "${WEBHOOK_POST_BACKUP_URL}" != "**None**" ]; then
+      echo "Execute post-backup webhook call to ${WEBHOOK_POST_BACKUP_URL}"
+      curl --request POST \
+        --url "${WEBHOOK_POST_BACKUP_URL}" \
+        --header 'Content-Type: application/json' \
+        --data '{"status": "error"}' \
+        --max-time 10 \
+        --retry 5 \
+        ${WEBHOOK_EXTRA_ARGS}
+    fi
+  ;;
+esac
+

--- a/hooks/00-webhook
+++ b/hooks/00-webhook
@@ -5,9 +5,9 @@ set -e
 # Possible actions: error, pre-backup, post-backup
 ACTION="${1}"
 
-if [ "${WEBHOOK_URL}" != "**None**" ]; then
-  case "${ACTION}" in
-    "error")
+case "${ACTION}" in
+  "error")
+    if [ "${WEBHOOK_URL}" != "**None**" ]; then
       echo "Execute error webhook call to ${WEBHOOK_URL}"
       curl --request POST \
         --url "${WEBHOOK_URL}" \
@@ -16,25 +16,7 @@ if [ "${WEBHOOK_URL}" != "**None**" ]; then
         --max-time 10 \
         --retry 5 \
         ${WEBHOOK_EXTRA_ARGS}
-      ;;
-#   "pre-backup")
-#     echo "Nothing to do"
-#     ;;
-    "post-backup")
-      echo "Execute post-backup webhook call to ${WEBHOOK_URL}"
-      curl --request POST \
-        --url "${WEBHOOK_URL}" \
-        --header 'Content-Type: application/json' \
-        --data '{"status": "post-backup"}' \
-        --max-time 10 \
-        --retry 5 \
-        ${WEBHOOK_EXTRA_ARGS}
-      ;;
-  esac
-fi
-
-case "${ACTION}" in
-  "error")
+    fi
     if [ "${WEBHOOK_ERROR_URL}" != "**None**" ]; then
       echo "Execute error webhook call to ${WEBHOOK_ERROR_URL}"
       curl --request POST \
@@ -61,6 +43,16 @@ case "${ACTION}" in
   ;;
 
   "post-backup")
+    if [ "${WEBHOOK_URL}" != "**None**" ]; then
+      echo "Execute post-backup webhook call to ${WEBHOOK_URL}"
+      curl --request POST \
+        --url "${WEBHOOK_URL}" \
+        --header 'Content-Type: application/json' \
+        --data '{"status": "post-backup"}' \
+        --max-time 10 \
+        --retry 5 \
+        ${WEBHOOK_EXTRA_ARGS}
+    fi
     if [ "${WEBHOOK_POST_BACKUP_URL}" != "**None**" ]; then
       echo "Execute post-backup webhook call to ${WEBHOOK_POST_BACKUP_URL}"
       curl --request POST \

--- a/hooks/00-webhook
+++ b/hooks/00-webhook
@@ -53,7 +53,7 @@ case "${ACTION}" in
       curl --request POST \
         --url "${WEBHOOK_PRE_BACKUP_URL}" \
         --header 'Content-Type: application/json' \
-        --data '{"status": "error"}' \
+        --data '{"status": "pre-backup"}' \
         --max-time 10 \
         --retry 5 \
         ${WEBHOOK_EXTRA_ARGS}
@@ -66,11 +66,10 @@ case "${ACTION}" in
       curl --request POST \
         --url "${WEBHOOK_POST_BACKUP_URL}" \
         --header 'Content-Type: application/json' \
-        --data '{"status": "error"}' \
+        --data '{"status": "post-backup"}' \
         --max-time 10 \
         --retry 5 \
         ${WEBHOOK_EXTRA_ARGS}
     fi
   ;;
 esac
-


### PR DESCRIPTION
## Why

The original implementation would call the webhooks for both success and failure. Without checking the contents of the JSON body a health check service would be unable to distinguish between those two.

Typical healthcheck provider would expect different endpoints for success, start, progress and failure (if the latter is are supported at all).

Here's one example: https://healthchecks.io/docs/signaling_failures/

## What 

This extends the webhook support to be friendlier with dead-man-switch health check services.

It adds 3 more optional env vars and will call the specified endpoints as needed.

| env var | description |
| ------- | ----------- |
| WEBHOOK_ERROR_URL | URL to be called in case backup fails. Default disabled. |
| WEBHOOK_PRE_BACKUP_URL | URL to be called when backup starts. Default disabled. |
| WEBHOOK_POST_BACKUP_URL | URL to be called when backup completes successfully. Default disabled. |

## Backwards compatibility

The original `WEBHOOK_URL` and its behaviour is untouched, so this change is 100% backwards compatible.
