### PR TITLE
Add PostgreSQL 18 Support

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,5 @@
 group "default" {
-	targets = ["debian-latest", "alpine-latest", "debian-16", "debian-15", "debian-14", "debian-13", "alpine-16", "alpine-15", "alpine-14", "alpine-13"]
+	targets = ["debian-latest", "alpine-latest", "debian-17", "debian-16", "debian-15", "debian-14", "debian-13", "alpine-17", "alpine-16", "alpine-15", "alpine-14", "alpine-13"]
 }
 
 variable "REGISTRY_PREFIX" {
@@ -27,20 +27,40 @@ target "alpine" {
 target "debian-latest" {
 	inherits = ["debian"]
 	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x", "linux/ppc64le"]
-	args = {"BASETAG" = "17"}
+	args = {"BASETAG" = "18"}
 	tags = [
 		"${REGISTRY_PREFIX}${IMAGE_NAME}:latest",
-		"${REGISTRY_PREFIX}${IMAGE_NAME}:17",
-		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:17-debian-${BUILD_REVISION}" : ""
+		"${REGISTRY_PREFIX}${IMAGE_NAME}:18",
+		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:18-debian-${BUILD_REVISION}" : ""
 	]
 }
 
 target "alpine-latest" {
 	inherits = ["alpine"]
 	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x", "linux/ppc64le"]
-	args = {"BASETAG" = "17-alpine"}
+	args = {"BASETAG" = "18-alpine"}
 	tags = [
 		"${REGISTRY_PREFIX}${IMAGE_NAME}:alpine",
+		"${REGISTRY_PREFIX}${IMAGE_NAME}:18-alpine",
+		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:18-alpine-${BUILD_REVISION}" : ""
+	]
+}
+
+target "debian-17" {
+	inherits = ["debian"]
+	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x", "linux/ppc64le"]
+	args = {"BASETAG" = "17"}
+	tags = [
+		"${REGISTRY_PREFIX}${IMAGE_NAME}:17",
+		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:17-debian-${BUILD_REVISION}" : ""
+	]
+}
+
+target "alpine-17" {
+	inherits = ["alpine"]
+	platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7", "linux/s390x", "linux/ppc64le"]
+	args = {"BASETAG" = "17-alpine"}
+	tags = [
 		"${REGISTRY_PREFIX}${IMAGE_NAME}:17-alpine",
 		notequal("", BUILD_REVISION) ? "${REGISTRY_PREFIX}${IMAGE_NAME}:17-alpine-${BUILD_REVISION}" : ""
 	]

--- a/generate-docker-bake.sh
+++ b/generate-docker-bake.sh
@@ -3,8 +3,8 @@
 set -e
 
 GOCRONVER="v0.0.11"
-MAIN_TAG="17"
-TAGS_EXTRA="16 15 14 13"
+MAIN_TAG="18"
+TAGS_EXTRA="17 16 15 14 13"
 PLATFORMS="linux/amd64 linux/arm64 linux/arm/v7 linux/s390x linux/ppc64le"
 DOCKER_BAKE_FILE="${1:-docker-bake.hcl}"
 


### PR DESCRIPTION
This commit updates the build scripts and configuration to make PostgreSQL 18 the default “latest” version:

- **docker-bake.hcl**  
  - Updated the `default` targets list to include `debian-17`/`alpine-17` and removed older `-16` as latest  
  - Changed `BASETAG` for `debian-latest` and `alpine-latest` to `18` and added corresponding `18` tags  
  - Added explicit `debian-17` and `alpine-17` targets to preserve PostgreSQL 17 support  
- **generate-docker-bake.sh**  
  - Bumped `MAIN_TAG` from `17` to `18`  
  - Updated `TAGS_EXTRA` to include `17` so previous versions remain supported  

These changes ensure that running `./generate-docker-bake.sh` now generates a `docker-bake.hcl` where `latest` images point to PostgreSQL 18, while still maintaining backward compatibility with versions 13–17.


https://www.postgresql.org/about/news/postgresql-18-released-3142/